### PR TITLE
Updated the Sound::Close funciton

### DIFF
--- a/DX11 Game/Utility/Sound.cpp
+++ b/DX11 Game/Utility/Sound.cpp
@@ -23,7 +23,8 @@ bool Sound::Initialize( HWND hwnd )
 void Sound::Close()
 {
 	// Frees the secondary buffer
-	CloseWavFile( &_secondaryBuffer[0] );
+	for (int i = 0; i < (sizeof(&_secondaryBuffer)/sizeof(&_secondaryBuffer[0])); i++)
+		CloseWavFile( &_secondaryBuffer[i] );
 	CloseDirectSound();
 }
 


### PR DESCRIPTION
Now actually loops through the secondary buffer array and deletes each instead of just the first one.