### PR TITLE
Updated includes and can "throw" cube

### DIFF
--- a/DX11 Game/Objects/Cube.cpp
+++ b/DX11 Game/Objects/Cube.cpp
@@ -27,6 +27,8 @@ bool Cube::Initialize( ID3D11DeviceContext* context, ID3D11Device* device )
         return false;
     }
     
+    delay = 0;
+
     return true;
 }
 
@@ -45,6 +47,21 @@ void Cube::Draw( ConstantBuffer<CB_VS_matrix>& cb_vs_matrix, ID3D11ShaderResourc
 void Cube::Update( const float deltaTime ) noexcept
 {
     if ( !isHeld ) physicsModel->Update( deltaTime / 20.0f );
+
+    else 
+        physicsModel->Update(deltaTime / 20.0f, true);
+
+    pos = GetPositionFloat3();
+
+    if (heldLastFrame && !isHeld && (pos.x != prevPos.x || pos.z != prevPos.z))
+        physicsModel->AddForce(XMFLOAT3((pos.x - prevPos.x) * 5.0f, 0.0f, (pos.z - prevPos.z) * 5.0f));
+
+    if (delay == 5)
+        prevPos = pos;
+    delay++;
+    if (delay > 5)
+        delay = 0;
+    heldLastFrame = isHeld;
 }
 
 #pragma region Collisions

--- a/DX11 Game/Objects/Cube.h
+++ b/DX11 Game/Objects/Cube.h
@@ -43,8 +43,15 @@ private:
 	IndexBuffer ib_cube;
 
 	bool isHeld = false;
+	bool heldLastFrame = false;
 	bool cubeHover = false;
 	bool cubeInRange = false;
+
+	int delay;
+
+	XMFLOAT3 prevPos;
+	XMFLOAT3 pos;
+
 };
 
 #endif

--- a/DX11 Game/Objects/Quad.cpp
+++ b/DX11 Game/Objects/Quad.cpp
@@ -1,6 +1,4 @@
 #include "Quad.h"
-#include "Indices.h"
-#include "Vertices.h"
 
 // NORMAL QUAD
 bool Quad::Initialize( ID3D11DeviceContext* context, ID3D11Device* device )

--- a/DX11 Game/Objects/RenderableGameObject.h
+++ b/DX11 Game/Objects/RenderableGameObject.h
@@ -5,6 +5,8 @@
 class Camera;
 class PhysicsModel;
 #include "GameObject3D.h"
+#include "Indices.h"
+#include "Vertices.h"
 
 /// <summary>
 /// Allows for a model to be bound to a 3D game object.

--- a/DX11 Game/Physics/PhysicsModel.cpp
+++ b/DX11 Game/Physics/PhysicsModel.cpp
@@ -8,20 +8,27 @@ PhysicsModel::PhysicsModel( GameObject* transform ) : mTransform( transform )
 	mUseLaminar = true;
 	mPosition = mTransform->GetPositionFloat3();
 
+	mIsHeld = false;
+
 	mFriction = { 0.0f, 0.0f, 0.0f };
 	mNetForce = { 0.0f, 0.0f, 0.0f };
 	mVelocity = { 0.0f, 0.0f, 0.0f };
 	mAcceleration = { 0.0f, 0.0f, 0.0f };
 }
 
-void PhysicsModel::Update( const float dt )
+void PhysicsModel::Update( const float dt, bool isHeld )
 {
+	mIsHeld = isHeld;
+
 	if ( !mActivated )
 	{
-		Weight();
+		if (!mIsHeld)
+		{
+			Weight();
+			Friction( dt );
+			Velocity(dt);
+		}
 		Acceleration();
-		Friction( dt );
-		Velocity( dt );
 		Drag();
 		ComputePosition( dt );
 		CheckFloorCollisions();

--- a/DX11 Game/Physics/PhysicsModel.h
+++ b/DX11 Game/Physics/PhysicsModel.h
@@ -18,7 +18,7 @@ public:
 	void SetActivated( bool activated ) noexcept { mActivated = activated; }
 
 	// Update Forces
-	virtual void Update( const float dt );
+	virtual void Update( const float dt, bool isHeld = false );
 	void AddForce( XMFLOAT3 force ) noexcept;
 	void ResetForces() noexcept;
 
@@ -58,6 +58,9 @@ private:
 	float mWeight;
 	bool mActivated;
 	bool mUseLaminar;
+
+	bool mIsHeld;
+
 	XMFLOAT3 mFriction;
 	XMFLOAT3 mPosition;
 	XMFLOAT3 mNetForce;

--- a/DX11 Game/imgui.ini
+++ b/DX11 Game/imgui.ini
@@ -20,7 +20,7 @@ Collapsed=0
 
 [Window][Scene Instructions]
 Pos=979,34
-Size=289,398
+Size=289,383
 Collapsed=0
 
 [Window][Directional Light]
@@ -30,8 +30,8 @@ Collapsed=1
 
 [Window][Point Light]
 Pos=23,40
-Size=291,183
-Collapsed=0
+Size=284,145
+Collapsed=1
 
 [Window][Spot Light]
 Pos=23,64


### PR DESCRIPTION
Added the Indices and Vertices header into RenderableGameObjects so they don't need to be included in both the Cube class and the Quad class. Updated Cube class so that when is stopped being held it has force in the direction that it travelled.