### PR TITLE
Updated tool and menu sounds

### DIFF
--- a/DX11 Game/Input/Input.cpp
+++ b/DX11 Game/Input/Input.cpp
@@ -387,16 +387,6 @@ void Input::UpdateMouse( const float dt )
 							cosf(levelSystem->GetCurrentLevel()->GetCube()[i]->GetRotationFloat3().y) * dt
 						);
 					}
-					
-				}
-
-				// testing sound, feel free to move or remove
-				if ( me.GetType() == Mouse::MouseEvent::EventType::LPress )
-				{
-					if ( levelSystem->GetCurrentLevel()->GetLevelName() == "MainMenu" ||  isPaused )
-						Sound::Instance()->PlaySoundEffect( "MenuClick" );
-					else
-						Sound::Instance()->PlaySoundEffect( "ToolUse" );
 				}
         
 #pragma region Tool_Picking

--- a/DX11 Game/Tool_Class.cpp
+++ b/DX11 Game/Tool_Class.cpp
@@ -133,9 +133,10 @@ void Tool_Class::HandleEvent(Event* event)
 				CubeProperties* cube = static_cast<CubeProperties*>(event->GetData());
 				ChangeCube(cube);
 
+				Sound::Instance()->PlaySoundEffect( "ToolUse" );
 			}
 			else if (_Energy <= 0) {
-
+				Sound::Instance()->PlaySoundEffect( "ToolNoEnergy" );
 			}
 		}
 	}

--- a/DX11 Game/UI/Wigets/Buttion_Widget.h
+++ b/DX11 Game/UI/Wigets/Buttion_Widget.h
@@ -108,6 +108,7 @@ inline bool Buttion_Widget<ButtionTexType>::Function(std::string text,vector<But
     	
     		ButtionColour = ButtionText[0];
     		IsPressed = true;
+            Sound::Instance()->PlaySoundEffect( "MenuClick" );
     		return true;
     		break;
     	case Hover:


### PR DESCRIPTION
The tool use sound now only plays when a cube is targeted and now has a no energy sound. The menu click sound now only plays when a button is pressed.