### PR TITLE
Updated cubes and pausing

### DIFF
--- a/DX11 Game/Credits_Level.cpp
+++ b/DX11 Game/Credits_Level.cpp
@@ -24,6 +24,8 @@ bool Credits_Level::OnCreate()
 void Credits_Level::OnSwitch()
 {	
 	levelName = "Credits";
+	numOfCubes = 0;
+	LevelContainer::UpdateCubes();
 
 	//new UI
 	_UiManager->RemoveAllUI();

--- a/DX11 Game/Graphics/TextRenderer.cpp
+++ b/DX11 Game/Graphics/TextRenderer.cpp
@@ -27,7 +27,7 @@ void TextRenderer::DrawString( const std::wstring& text, XMFLOAT2 position, XMVE
 
 void TextRenderer::RenderCubeMoveText( LevelContainer& level )
 {
-	for ( uint32_t i = 0; i < NUM_CUBES; i++ )
+	for ( uint32_t i = 0; i < level.GetNumOfLevelCubes(); i++ )
 	{
 		if ( level.GetCube()[i]->GetIsInRange() && level.GetCube()[i]->GetIsHovering() && !level.GetCube()[i]->GetIsHolding() )
 		{

--- a/DX11 Game/Input/Input.cpp
+++ b/DX11 Game/Input/Input.cpp
@@ -157,39 +157,42 @@ void Input::UpdateKeyboard( const float dt )
 		// MULTI-TOOL INPUT
 		{
 			// set multi-tool type
-			if ( keycode == KeyBinds["Gun_State_One"] ) {
-				currentTool = ToolType::Convert;
-				EventSystem::Instance()->AddEvent( EVENTID::ChangeToolEvent, &currentTool );
-				Sound::Instance()->PlaySoundEffect( "ToolSwitchMode" );
-			}
-			if ( keycode == KeyBinds["Gun_State_Two"] ) {
-				currentTool = ToolType::Resize;
-				EventSystem::Instance()->AddEvent( EVENTID::ChangeToolEvent, &currentTool );
-				Sound::Instance()->PlaySoundEffect( "ToolSwitchMode" );
-			}
-			if ( keycode == KeyBinds["Gun_State_Three"] ) {
-				currentTool = ToolType::Bounce;
-				EventSystem::Instance()->AddEvent( EVENTID::ChangeToolEvent, &currentTool );
-				Sound::Instance()->PlaySoundEffect( "ToolSwitchMode" );
-			}
-			if (keycode == KeyBinds["Gun_State_Four"]) {
-				currentTool = ToolType::Magnetism;
-				EventSystem::Instance()->AddEvent(EVENTID::ChangeToolEvent, &currentTool);
-				Sound::Instance()->PlaySoundEffect("ToolSwitchMode");
-			}
-			if (keycode == KeyBinds["Gun_State_Five"]) {
-				currentTool = ToolType::Conductive;
-				EventSystem::Instance()->AddEvent(EVENTID::ChangeToolEvent, &currentTool);
-				Sound::Instance()->PlaySoundEffect("ToolSwitchMode");
-			}
-			if ( keycode == KeyBinds["Gun_State_Six"] );
-
-			if (kbe.IsPress()) {
-				if (keycode == KeyBinds["Change_Gun_State_Up"]) {
-					EventSystem::Instance()->AddEvent(EVENTID::ChangeToolOptionUpEvent);
+			if (!isPaused)
+			{
+				if (keycode == KeyBinds["Gun_State_One"]) {
+					currentTool = ToolType::Convert;
+					EventSystem::Instance()->AddEvent(EVENTID::ChangeToolEvent, &currentTool);
+					Sound::Instance()->PlaySoundEffect("ToolSwitchMode");
 				}
-				else if (keycode == KeyBinds["Change_Gun_State_Down"]) {
-					EventSystem::Instance()->AddEvent(EVENTID::ChangeToolOptionDownEvent);
+				if (keycode == KeyBinds["Gun_State_Two"]) {
+					currentTool = ToolType::Resize;
+					EventSystem::Instance()->AddEvent(EVENTID::ChangeToolEvent, &currentTool);
+					Sound::Instance()->PlaySoundEffect("ToolSwitchMode");
+				}
+				if (keycode == KeyBinds["Gun_State_Three"]) {
+					currentTool = ToolType::Bounce;
+					EventSystem::Instance()->AddEvent(EVENTID::ChangeToolEvent, &currentTool);
+					Sound::Instance()->PlaySoundEffect("ToolSwitchMode");
+				}
+				if (keycode == KeyBinds["Gun_State_Four"]) {
+					currentTool = ToolType::Magnetism;
+					EventSystem::Instance()->AddEvent(EVENTID::ChangeToolEvent, &currentTool);
+					Sound::Instance()->PlaySoundEffect("ToolSwitchMode");
+				}
+				if (keycode == KeyBinds["Gun_State_Five"]) {
+					currentTool = ToolType::Conductive;
+					EventSystem::Instance()->AddEvent(EVENTID::ChangeToolEvent, &currentTool);
+					Sound::Instance()->PlaySoundEffect("ToolSwitchMode");
+				}
+				if (keycode == KeyBinds["Gun_State_Six"]);
+
+				if (kbe.IsPress()) {
+					if (keycode == KeyBinds["Change_Gun_State_Up"]) {
+						EventSystem::Instance()->AddEvent(EVENTID::ChangeToolOptionUpEvent);
+					}
+					else if (keycode == KeyBinds["Change_Gun_State_Down"]) {
+						EventSystem::Instance()->AddEvent(EVENTID::ChangeToolOptionDownEvent);
+					}
 				}
 			}
 		}
@@ -222,24 +225,27 @@ void Input::UpdateKeyboard( const float dt )
 			if ( keyboard.KeyIsPressed( VK_SPACE ) ) CameraMovement::MoveUp( cameras->GetCamera( JSON::CameraType::Debug ), dt );
 			if ( keyboard.KeyIsPressed( VK_CONTROL ) ) CameraMovement::MoveDown( cameras->GetCamera( JSON::CameraType::Debug ), dt );
 		}
-		else
+		else if ( !isPaused )
 		{
 			static bool jumping = false;
 			if ( keyboard.KeyIsPressed( KeyBinds["Jump"] ) || jumping )
 				CameraMovement::Jump( cameras->GetCamera( JSON::CameraType::Default ), jumping, dt );
 		}
 
-		// normalize diagonal movement speed
-		if ( keyboard.KeyIsPressed( KeyBinds["Forward"] ) && ( keyboard.KeyIsPressed( KeyBinds["Left"] ) || keyboard.KeyIsPressed( KeyBinds["Back"] ) ) )
-			cameras->GetCamera( cameras->GetCurrentCamera() )->SetCameraSpeed( 0.008f );
-		if ( keyboard.KeyIsPressed( KeyBinds["Back"] ) && ( keyboard.KeyIsPressed( KeyBinds["Left"] ) || keyboard.KeyIsPressed( KeyBinds["Back"] ) ) )
-			cameras->GetCamera( cameras->GetCurrentCamera() )->SetCameraSpeed( 0.008f );
+		if (!isPaused)
+		{
+			// normalize diagonal movement speed
+			if (keyboard.KeyIsPressed(KeyBinds["Forward"]) && (keyboard.KeyIsPressed(KeyBinds["Left"]) || keyboard.KeyIsPressed(KeyBinds["Back"])))
+				cameras->GetCamera(cameras->GetCurrentCamera())->SetCameraSpeed(0.008f);
+			if (keyboard.KeyIsPressed(KeyBinds["Back"]) && (keyboard.KeyIsPressed(KeyBinds["Left"]) || keyboard.KeyIsPressed(KeyBinds["Back"])))
+				cameras->GetCamera(cameras->GetCurrentCamera())->SetCameraSpeed(0.008f);
 
-		// update camera movement
-		if ( keyboard.KeyIsPressed( KeyBinds["Forward"] ) ) CameraMovement::MoveForward( cameras->GetCamera( cameras->GetCurrentCamera() ), playMode, dt );
-		if ( keyboard.KeyIsPressed( KeyBinds["Left"] ) ) CameraMovement::MoveLeft( cameras->GetCamera( cameras->GetCurrentCamera() ), playMode, dt );
-		if ( keyboard.KeyIsPressed( KeyBinds["Back"] ) ) CameraMovement::MoveBackward( cameras->GetCamera( cameras->GetCurrentCamera() ), playMode, dt );
-		if ( keyboard.KeyIsPressed( KeyBinds["Right"] ) ) CameraMovement::MoveRight( cameras->GetCamera( cameras->GetCurrentCamera() ), playMode, dt );
+			// update camera movement
+			if (keyboard.KeyIsPressed(KeyBinds["Forward"])) CameraMovement::MoveForward(cameras->GetCamera(cameras->GetCurrentCamera()), playMode, dt);
+			if (keyboard.KeyIsPressed(KeyBinds["Left"])) CameraMovement::MoveLeft(cameras->GetCamera(cameras->GetCurrentCamera()), playMode, dt);
+			if (keyboard.KeyIsPressed(KeyBinds["Back"])) CameraMovement::MoveBackward(cameras->GetCamera(cameras->GetCurrentCamera()), playMode, dt);
+			if (keyboard.KeyIsPressed(KeyBinds["Right"])) CameraMovement::MoveRight(cameras->GetCamera(cameras->GetCurrentCamera()), playMode, dt);
+		}
 
 		// set camera speed
 		cameras->GetCamera( cameras->GetCurrentCamera() )->SetCameraSpeed( 0.01f );
@@ -248,61 +254,70 @@ void Input::UpdateKeyboard( const float dt )
 	// MULTI-TOOL INPUT
 	{
 		// set multi-tool type
-		for ( uint32_t i = 0; i < NUM_CUBES; i++ )
+		if (!isPaused)
 		{
-			// ensure another cube is not already being held
-			float alreadyHeld = false;
-			for ( uint32_t j = 0; j < NUM_CUBES; j++ )
-				if ( i != j && levelSystem->GetCurrentLevel()->GetCube()[j]->GetIsHolding() == true )
-					alreadyHeld = true;
-
-	
-
-			// pickup cube is in range, hovering with mouse and not already holding a cube - toggle function - was ( ( GetKeyState( KeyBindes["Action"] ) & 0x0001 ) != 0
-			if ( ( keyboard.KeyIsPressed( KeyBinds["Action"] ) ) &&
-				!alreadyHeld && levelSystem->GetCurrentLevel()->GetCube()[i]->GetIsInRange() && canHover && !levelSystem->GetCurrentLevel()->GetCube()[i]->GetIsDissCube() &&
-				( levelSystem->GetCurrentLevel()->GetCube()[i]->GetIsHovering() || levelSystem->GetCurrentLevel()->GetCube()[i]->GetIsHolding() ) )
+			for (uint32_t i = 0; i < levelSystem->GetCurrentLevel()->GetNumOfLevelCubes(); i++)
 			{
-				levelSystem->GetCurrentLevel()->GetCube()[i]->SetIsHolding( true );
-				levelSystem->GetCurrentLevel()->GetCube()[i]->GetPhysicsModel()->ResetForces();
+				// ensure another cube is not already being held
+				float alreadyHeld = false;
+				for (uint32_t j = 0; j < levelSystem->GetCurrentLevel()->GetNumOfLevelCubes(); j++)
+					if (i != j && levelSystem->GetCurrentLevel()->GetCube()[j]->GetIsHolding() == true)
+						alreadyHeld = true;
 
-				if (!heldLastFrame[i])
-					Sound::Instance()->PlaySoundEffect( "CubePickup" );
 
-				// set cube position
-				static int offset = 2;
-				switch ( levelSystem->GetCurrentLevel()->GetCube()[i]->GetEditableProperties()->GetBoxSize() )
+
+				// pickup cube is in range, hovering with mouse and not already holding a cube - toggle function - was ( ( GetKeyState( KeyBindes["Action"] ) & 0x0001 ) != 0
+				if ((keyboard.KeyIsPressed(KeyBinds["Action"])) &&
+					!alreadyHeld && levelSystem->GetCurrentLevel()->GetCube()[i]->GetIsInRange() && canHover && !levelSystem->GetCurrentLevel()->GetCube()[i]->GetIsDissCube() &&
+					(levelSystem->GetCurrentLevel()->GetCube()[i]->GetIsHovering() || levelSystem->GetCurrentLevel()->GetCube()[i]->GetIsHolding()))
 				{
-				case BoxSize::Small:  offset = 1; break;
-				case BoxSize::Normal: offset = 2; break;
-				case BoxSize::Large:  offset = 4; break;
-				}
-				XMVECTOR cubePosition = cameras->GetCamera( cameras->GetCurrentCamera() )->GetPositionVector();
-				cubePosition += cameras->GetCamera( cameras->GetCurrentCamera() )->GetForwardVector() * offset;
-				levelSystem->GetCurrentLevel()->GetCube()[i]->SetPosition( cubePosition );
+					levelSystem->GetCurrentLevel()->GetCube()[i]->SetIsHolding(true);
+					levelSystem->GetCurrentLevel()->GetCube()[i]->GetPhysicsModel()->ResetForces();
 
-				// set cube rotation
-				levelSystem->GetCurrentLevel()->GetCube()[i]->SetRotation(
-					levelSystem->GetCurrentLevel()->GetCube()[i]->GetRotationFloat3().x,
-					cameras->GetCamera( cameras->GetCurrentCamera() )->GetRotationFloat3().y,
-					levelSystem->GetCurrentLevel()->GetCube()[i]->GetRotationFloat3().z
-				);
-        
-				heldLastFrame[i] = true;
+					if (!heldLastFrame[i])
+						Sound::Instance()->PlaySoundEffect("CubePickup");
+
+					// set cube position
+					static int offset = 2;
+					switch (levelSystem->GetCurrentLevel()->GetCube()[i]->GetEditableProperties()->GetBoxSize())
+					{
+					case BoxSize::Small:  offset = 1; break;
+					case BoxSize::Normal: offset = 2; break;
+					case BoxSize::Large:  offset = 4; break;
+					}
+					XMVECTOR cubePosition = cameras->GetCamera(cameras->GetCurrentCamera())->GetPositionVector();
+					cubePosition += cameras->GetCamera(cameras->GetCurrentCamera())->GetForwardVector() * offset;
+					levelSystem->GetCurrentLevel()->GetCube()[i]->SetPosition(cubePosition);
+
+					// set cube rotation
+					levelSystem->GetCurrentLevel()->GetCube()[i]->SetRotation(
+						levelSystem->GetCurrentLevel()->GetCube()[i]->GetRotationFloat3().x,
+						cameras->GetCamera(cameras->GetCurrentCamera())->GetRotationFloat3().y,
+						levelSystem->GetCurrentLevel()->GetCube()[i]->GetRotationFloat3().z
+					);
+
+					heldLastFrame[i] = true;
+				}
+				else
+				{
+					levelSystem->GetCurrentLevel()->GetCube()[i]->SetIsHolding(false);
+					heldLastFrame[i] = false;
+				}
 			}
+
+			if (!canHover && delay < 100.0f)
+				delay += 1.0f;
 			else
 			{
-				levelSystem->GetCurrentLevel()->GetCube()[i]->SetIsHolding( false );
-				heldLastFrame[i] = false;
+				canHover = true;
+				delay = 0.0f;
 			}
 		}
 
-		if ( !canHover && delay < 100.0f )
-			delay += 1.0f;
 		else
 		{
-			canHover = true;
-			delay = 0.0f;
+			for (int i = 0; i < levelSystem->GetCurrentLevel()->GetNumOfLevelCubes(); i++)
+				levelSystem->GetCurrentLevel()->GetCube()[i]->SetIsHolding(false);
 		}
 	}
 #pragma endregion
@@ -336,36 +351,39 @@ void Input::UpdateMouse( const float dt )
 
 		// MULTI-TOOL INPUT
 		{
-			if (me.GetType() == MouseBinds["Change_Gun_State_Up"])
+			if (!isPaused)
 			{
-				EventSystem::Instance()->AddEvent(EVENTID::ChangeToolOptionUpEvent);
-				Sound::Instance()->PlaySoundEffect( "ToolChange" );
-			}
-			else if (me.GetType() == MouseBinds["Change_Gun_State_Down"])
-			{
-				EventSystem::Instance()->AddEvent(EVENTID::ChangeToolOptionDownEvent);
-				Sound::Instance()->PlaySoundEffect("ToolChange");
-			}
+				if (me.GetType() == MouseBinds["Change_Gun_State_Up"])
+				{
+					EventSystem::Instance()->AddEvent(EVENTID::ChangeToolOptionUpEvent);
+					Sound::Instance()->PlaySoundEffect("ToolChange");
+				}
+				else if (me.GetType() == MouseBinds["Change_Gun_State_Down"])
+				{
+					EventSystem::Instance()->AddEvent(EVENTID::ChangeToolOptionDownEvent);
+					Sound::Instance()->PlaySoundEffect("ToolChange");
+				}
 
-			//mag mode all
+				//mag mode all
 				if (me.GetType() == MouseBinds["Fire_Tool"]) {
 					EventSystem::Instance()->AddEvent(EVENTID::ChangeAllCubeEvent, &levelSystem->GetCurrentLevel()->GetCube());
-					
+
 				}
+			}
 			// mouse picking
 			mousePick.UpdateMatrices( cameras->GetCamera( cameras->GetCurrentCamera() ) );
-			for ( uint32_t i = 0; i < NUM_CUBES; i++ )
+			for ( uint32_t i = 0; i < levelSystem->GetCurrentLevel()->GetNumOfLevelCubes(); i++ )
 			{
 				//cube mouse input
 				{
 					float alreadyHeld = false;
-					for (uint32_t j = 0; j < NUM_CUBES; j++) {
+					for (uint32_t j = 0; j < levelSystem->GetCurrentLevel()->GetNumOfLevelCubes(); j++) {
 						if (i != j && levelSystem->GetCurrentLevel()->GetCube()[j]->GetIsHolding() == true) {
 							alreadyHeld = true;
 						}
 					}
 					// cube throwing
-					if (me.GetType() == MouseBinds["Fire_Tool_Alt"] && !alreadyHeld && levelSystem->GetCurrentLevel()->GetCube()[i]->GetIsInRange() && canHover && 
+					if (me.GetType() == MouseBinds["Fire_Tool_Alt"] && !alreadyHeld && levelSystem->GetCurrentLevel()->GetCube()[i]->GetIsInRange() && canHover && !isPaused &&
 						!levelSystem->GetCurrentLevel()->GetCube()[i]->GetIsDissCube() && levelSystem->GetCurrentLevel()->GetCube()[i]->GetIsHolding() &&
 						(levelSystem->GetCurrentLevel()->GetCube()[i]->GetIsHovering() || levelSystem->GetCurrentLevel()->GetCube()[i]->GetIsHolding()))
 					{

--- a/DX11 Game/Levels/Level1.cpp
+++ b/DX11 Game/Levels/Level1.cpp
@@ -50,6 +50,8 @@ void Level1::OnSwitch()
 	EventSystem::Instance()->AddEvent(EVENTID::SetCurrentLevelEvent, &CurrentLevel);
 
 	levelName = "Level1";
+	numOfCubes = 1;
+	LevelContainer::UpdateCubes( 0.0f, 0.0f, -4.0f );
 	NextLevel = 2;
 	EventSystem::Instance()->AddEvent(EVENTID::SetNextLevelEvent, &NextLevel);
 
@@ -149,7 +151,7 @@ void Level1::Update( const float dt )
 		Collisions::CheckCollisionLevel1( cameras->GetCamera( JSON::CameraType::Default ), room, 19.0f );
 
 		// cube collisions
-		for ( uint32_t i = 0; i < NUM_CUBES; i++ )
+		for ( uint32_t i = 0; i < numOfCubes; i++ )
 		{
 			// update collisions w pressure plate
 			if ( cubes[i]->CheckCollisionAABB( pressurePlate, dt ) )
@@ -163,7 +165,7 @@ void Level1::Update( const float dt )
 			}
 
 			// update collisions w other cubes
-			for ( uint32_t j = 0; j < NUM_CUBES; j++ )
+			for ( uint32_t j = 0; j < numOfCubes; j++ )
 				if ( i != j )
 					cubes[i]->CheckCollisionAABB( cubes[j], dt );
 

--- a/DX11 Game/Levels/Level2.cpp
+++ b/DX11 Game/Levels/Level2.cpp
@@ -41,6 +41,8 @@ void Level2::OnSwitch()
 
 	// update items on level switch here...
 	levelName = "Level2";
+	numOfCubes = 3;
+	LevelContainer::UpdateCubes();
 	NextLevel = 3;
 	//UI
 	_UiManager->RemoveUI("MainMenu");

--- a/DX11 Game/Levels/LevelContainer.cpp
+++ b/DX11 Game/Levels/LevelContainer.cpp
@@ -40,19 +40,6 @@ bool LevelContainer::InitializeScene()
 	{
 		// DRAWABLES
 		{
-			// cubes
-			for ( uint32_t i = 0; i < NUM_CUBES; i++ )
-			{
-				std::shared_ptr<Cube> cube = std::make_shared<Cube>();
-				if ( !cube->Initialize( graphics->context.Get(), graphics->device.Get() ) ) return false;
-
-				float xPos = 2.5f;
-				if ( i % 2 == 0 ) xPos = -xPos;
-				cube->SetInitialPosition( xPos, 0.0f, -6.0f );
-
-				cubes.push_back( std::move( cube ) );
-			}
-
 			// skysphere
 			if ( !skysphere.Initialize( "Resources\\Models\\Sphere\\sphere.obj", graphics->device.Get(), graphics->context.Get(), cb_vs_matrix ) ) return false;
 			skysphere.SetInitialScale( 250.0f, 250.0f, 250.0f );
@@ -173,7 +160,7 @@ void LevelContainer::RenderFrame()
 	// DRAWABLES
 	{
 		// CUBES
-		for ( uint32_t i = 0; i < NUM_CUBES; i++ )
+		for ( uint32_t i = 0; i < numOfCubes; i++ )
 		{
 			// render backfaces
 			if ( cubes[i]->GetEditableProperties()->GetBoxType() == BoxType::Mesh )
@@ -246,7 +233,7 @@ void LevelContainer::Update( const float dt )
 void LevelContainer::LateUpdate( const float dt )
 {
 	// update cubes
-	for ( uint32_t i = 0; i < NUM_CUBES; i++ )
+	for ( uint32_t i = 0; i < numOfCubes; i++ )
 	{
 		cubes[i]->SetCamPos(cameras->GetCamera(cameras->GetCurrentCamera())->GetPositionFloat3());
 		// update cube scale multiplier
@@ -276,4 +263,19 @@ void LevelContainer::LateUpdate( const float dt )
 
 	// set position of spot light model
 	spotLight.UpdateModelPosition( cameras->GetCamera( JSON::CameraType::Default ) );
+}
+
+void LevelContainer::UpdateCubes( float xPos, float yPos, float zPos, float spacing )
+{
+	cubes.clear();
+
+	for (uint32_t i = 0; i < numOfCubes; i++)
+	{
+		std::shared_ptr<Cube> cube = std::make_shared<Cube>();
+		if (!cube->Initialize(graphics->context.Get(), graphics->device.Get())) return;
+
+		cube->SetInitialPosition(xPos + ( i * spacing ) , yPos, zPos);
+
+		cubes.push_back(std::move(cube));
+	}
 }

--- a/DX11 Game/Levels/LevelContainer.h
+++ b/DX11 Game/Levels/LevelContainer.h
@@ -46,6 +46,7 @@ public:
 	virtual void RenderFrame();
 	virtual void Update( const float dt );
 	void LateUpdate( const float dt );
+	void UpdateCubes( float xPos = -2.5f, float yPos = 0.0f, float zPos = -6.0f, float spacing = 2.5f );
 
 	// not sure i like using this. Could pass cameras to textRenderer instead of having a passthrough of gets
 	std::shared_ptr<StencilOutline> GetStencilOutline() const noexcept { return stencilOutline; }
@@ -58,6 +59,7 @@ public:
 	Tool_Class* GetTool() { return tool; }
 
 	std::string GetLevelName() { return levelName; }
+	int GetNumOfLevelCubes() { return numOfCubes; }
   
 protected:
 	void RenderFrameEarly();
@@ -89,6 +91,7 @@ protected:
 	std::string levelName;
 	UINT32 NextLevel;
 	UINT32 CurrentLevel;
+	int numOfCubes;
 private:
 	bool InitializeScene();
 

--- a/DX11 Game/MainMenu_Level.cpp
+++ b/DX11 Game/MainMenu_Level.cpp
@@ -28,6 +28,8 @@ void MainMenu_Level::OnSwitch()
 {
 	// update items on level switch here...
 	levelName = "MainMenu";
+	numOfCubes = 0;
+	LevelContainer::UpdateCubes();
 
 	//make sure cursor is displayed
 	EventSystem::Instance()->AddEvent(EVENTID::ShowCursorEvent);

--- a/DX11 Game/Objects/Cube.cpp
+++ b/DX11 Game/Objects/Cube.cpp
@@ -90,12 +90,7 @@ void Cube::Update( const float deltaTime ) noexcept
     MagneticForce();
 
     // update physics
-    if (!isHeld) {
-      
-        physicsModel->Update(deltaTime / 20.0f, editableProperties);
-    }
-    else
-        physicsModel->Update( deltaTime / 20.0f, editableProperties, true );
+    physicsModel->Update( deltaTime / 20.0f, editableProperties, isHeld );
 
     // update positioning
     pos = GetPositionFloat3();


### PR DESCRIPTION
When the game is paused more of the players actions should now be prohibited like walking and interacting with the cubes.
You can now choose how many cubes spawn per level, where they initially spawn and what their spacing is (x-axis). Must now define numOfCubes at the start of each level and run the UpdateCubes function from levelcontainer